### PR TITLE
fix: add the bin attribute for npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "private": false,
   "main": "src/cli.js",
+  "bin": "./src/cli.js",
   "engines": {
     "node": "v20"
   },


### PR DESCRIPTION
currently we got:
> npx @outlierventures/arweave-bundler upload build/ --private-key ${PRIVATE_KEY} --dry-run
> npm ERR! could not determine executable to run

Adding the `bin` attribute in the package. You can run in local to check that now it's working with:
`npx . upload build/ --private-key ${PRIVATE_KEY} --dry-run` 