### PR TITLE
new dir to encapsulate upload command

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@actions/core':
     specifier: ^1.10.1
@@ -2640,3 +2636,7 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,19 +1,9 @@
 #!/usr/bin/env node
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
-import upload from './commands/upload.js'
+import upload from './commands/uploadCommand.js'
 
 yargs(hideBin(process.argv))
   .demandCommand(1, 'You need to specify a command')
   .command(upload.command, upload.description, upload.builder, upload.handler)
-  .option('private-key', {
-    describe:
-      'Path to the private key file (default: wallet.json) or base64 encoded private key (JWK)',
-    type: 'string',
-  })
-  .option('dry-run', {
-    describe: 'run everything expect submitting the transaction',
-    type: 'boolean',
-    default: false,
-  })
   .help().argv

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,37 +1,11 @@
 #!/usr/bin/env node
 import yargs from 'yargs'
-import fs from 'fs'
 import { hideBin } from 'yargs/helpers'
-import { upload } from './upload.js'
+import upload from './commands/upload.js'
 
 yargs(hideBin(process.argv))
   .demandCommand(1, 'You need to specify a command')
-  .command(
-    'upload <directory>',
-    'Upload a directory to Arweave as bundle',
-    (yargs) => {
-      yargs.positional('directory', {
-        describe: 'The directory containing files to upload',
-        type: 'string',
-      })
-    },
-    async (argv) => {
-      const { directory, dryRun } = argv
-      // console.log({ directory, privateKey, dryRun })
-      let privateKey
-      try {
-        privateKey = argv.privateKey
-          ? JSON.parse(Buffer.from(argv.privateKey, 'base64').toString('utf-8'))
-          : JSON.parse(fs.readFileSync('wallet.json'))
-      } catch (e) {
-        throw new Error(
-          'missing private key as base64 of a wallet.json or missing wallet.json',
-        )
-      }
-
-      return await upload(directory, privateKey, dryRun)
-    },
-  )
+  .command(upload.command, upload.description, upload.builder, upload.handler)
   .option('private-key', {
     describe:
       'Path to the private key file (default: wallet.json) or base64 encoded private key (JWK)',

--- a/src/commands/upload.js
+++ b/src/commands/upload.js
@@ -1,0 +1,33 @@
+import { upload } from '../upload.js'
+
+export const command = 'upload <directory>'
+export const description = 'Upload a directory to Arweave as bundle'
+
+export const builder = (yargs) => {
+  yargs.positional('directory', {
+    describe: 'The directory containing files to upload',
+    type: 'string',
+  })
+}
+
+export const handler = async (argv) => {
+  const { directory, dryRun } = argv
+  let privateKey
+  try {
+    privateKey = argv.privateKey
+      ? JSON.parse(Buffer.from(argv.privateKey, 'base64').toString('utf-8'))
+      : JSON.parse(fs.readFileSync('wallet.json'))
+  } catch (e) {
+    throw new Error(
+      'missing private key as base64 of a wallet.json or missing wallet.json',
+    )
+  }
+  return await upload(directory, privateKey, dryRun)
+}
+
+export default {
+    command,
+    description,
+    builder,
+    handler
+}

--- a/src/commands/uploadCommand.js
+++ b/src/commands/uploadCommand.js
@@ -8,6 +8,16 @@ export const builder = (yargs) => {
     describe: 'The directory containing files to upload',
     type: 'string',
   })
+  .option('private-key', {
+    describe:
+      'Path to the private key file (default: wallet.json) or base64 encoded private key (JWK)',
+    type: 'string',
+  })
+  .option('dry-run', {
+    describe: 'run everything expect submitting the transaction',
+    type: 'boolean',
+    default: false,
+  })
 }
 
 export const handler = async (argv) => {


### PR DESCRIPTION
Created `src/commands` directory to encapsulate commands outside of `cli.js` and moved the `upload` command